### PR TITLE
log the URL for accessing the Spotlight overlay and show it when sidecar is already running

### DIFF
--- a/.changeset/perfect-laws-burn.md
+++ b/.changeset/perfect-laws-burn.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/sidecar': patch
+---
+
+Improve DX by always showing the Spotlight URL, even if the sidecar was already running. Makes it easy to cmd/ctrl+click
+and open in browser.

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -305,6 +305,10 @@ function errorResponse(code: number) {
 const error404 = errorResponse(404);
 const error405 = errorResponse(405);
 
+function logSpotlightUrl(port: number): void {
+  logger.info(`You can open: http://localhost:${port} to see the Spotlight overlay directly`);
+}
+
 function startServer(
   buffer: MessageBuffer<Payload>,
   port: number,
@@ -392,7 +396,7 @@ function startServer(
   function handleServerListen(port: number, basePath?: string): void {
     logger.info(`Sidecar listening on ${port}`);
     if (basePath) {
-      logger.info(`You can open: http://localhost:${port} to see the Spotlight overlay directly`);
+      logSpotlightUrl(port);
     }
   }
 }
@@ -485,6 +489,7 @@ export function setupSidecar({
   isSidecarRunning(sidecarPort).then((isRunning: boolean) => {
     if (isRunning) {
       logger.info(`Sidecar is already running on port ${sidecarPort}`);
+      logSpotlightUrl(sidecarPort);
     } else if (!serverInstance) {
       serverInstance = startServer(buffer, sidecarPort, basePath, filesToServe, incomingPayload);
     }

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -489,7 +489,10 @@ export function setupSidecar({
   isSidecarRunning(sidecarPort).then((isRunning: boolean) => {
     if (isRunning) {
       logger.info(`Sidecar is already running on port ${sidecarPort}`);
-      logSpotlightUrl(sidecarPort);
+      const hasSpotlightUI = (filesToServe && '/src/index.html' in filesToServe) || (!filesToServe && basePath);
+      if (hasSpotlightUI) {
+        logSpotlightUrl(sidecarPort);
+      }
     } else if (!serverInstance) {
       serverInstance = startServer(buffer, sidecarPort, basePath, filesToServe, incomingPayload);
     }

--- a/packages/website/src/content/docs/contribute/index.mdx
+++ b/packages/website/src/content/docs/contribute/index.mdx
@@ -17,7 +17,7 @@ Make sure you [enable `pnpm` support for `Volta`](https://docs.volta.sh/advanced
 
 ```shell
 # Add this to your profile file or startup script
-VOLTA_FEATURE_PNPM=1
+export VOLTA_FEATURE_PNPM=1
 ```
 
 :::


### PR DESCRIPTION
Small DX improvement: sidecar now always logs the Spotlight URL, even if it was already running. Makes it easy to _cmd/ctrl+click_ and open in browser.

Previous behavior:
![Screenshot 2025-03-23 at 20 18 37](https://github.com/user-attachments/assets/81972e0e-9cae-4710-94d2-f6cdd46c1fe6)

New behavior (notice the final line):
![Screenshot 2025-03-23 at 20 19 23](https://github.com/user-attachments/assets/49314cd8-246d-480b-8670-b2b4edc00df4)


Before opening this PR:

- [ x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses
